### PR TITLE
Modification of the system zone in the main dialog to make it editable.

### DIFF
--- a/addon/globalPlugins/openai/maindialog.py
+++ b/addon/globalPlugins/openai/maindialog.py
@@ -474,7 +474,7 @@ class OpenAIDlg(wx.Dialog):
 		self.systemText = wx.TextCtrl(
 			parent=self,
 			size=(550, -1),
-			style=wx.TE_MULTILINE|wx.TE_READONLY,
+			style=wx.TE_MULTILINE,
 		)
 		if conf["saveSystem"] and self._lastSystem:
 			self.systemText.SetValue(self._lastSystem)


### PR DESCRIPTION
In the main dialog, currently, it is not possible to write in the system zone as it is read-only. I have modified the attributes of the zone to make it editable.