### PR TITLE
Changing of the context window label to maximum input tokens

### DIFF
--- a/addon/globalPlugins/openai/model.py
+++ b/addon/globalPlugins/openai/model.py
@@ -30,7 +30,7 @@ class Model:
 		maxOutputToken = self.maxOutputToken
 		s = f"{name} ({description}"
 		if contextWindow > 0:
-			label = _("Context window:")
+			label = _("Maximum input tokens")
 			s += f". {label} {contextWindow}"
 		if maxOutputToken > 0:
 			label = _("max output token:")


### PR DESCRIPTION
I changed the "context window" label to "maximum input tokens" because I don't understand the meaning of that label in this context.