### PR TITLE
Change of the main dialog name when an organization is used

### DIFF
--- a/addon/globalPlugins/openai/__init__.py
+++ b/addon/globalPlugins/openai/__init__.py
@@ -36,6 +36,7 @@ ADDON_INFO = addonHandler.Addon(
 
 confSpecs = {
 	"use_org": "boolean(default=False)",
+	"orgName": 'string(default="")',
 	"model": f"string(default={DEFAULT_MODEL.name})",
 	"topP": f"integer(min={TOP_P_MIN}, max={TOP_P_MAX}, default={DEFAULT_TOP_P})",
 	"n": f"integer(min={N_MIN}, max={N_MAX}, default={DEFAULT_N})",
@@ -272,6 +273,7 @@ class SettingsDlg(gui.settingsDialogs.SettingsPanel):
 			if not org_name:
 				self.org_name.SetFocus()
 				return
+			conf["orgName"] = org_name
 		api_key_manager.save_api_key(
 			api_key_org,
 			org=True,

--- a/addon/globalPlugins/openai/maindialog.py
+++ b/addon/globalPlugins/openai/maindialog.py
@@ -396,7 +396,7 @@ class OpenAIDlg(wx.Dialog):
 			self._lastSystem = self.data.get("system", "")
 		if not title:
 			title = "Open AI - %s" % (
-				_("organization") if conf["use_org"] else _("personal")
+				conf["orgName"] if conf["use_org"] else _("personal")
 			)
 		super().__init__(parent, title=title)
 


### PR DESCRIPTION
Use the organization name entered in settings as the main dialog title.