### PR TITLE
API Key Manager: fix incorrect calls for `ready()`

### DIFF
--- a/addon/globalPlugins/openai/__init__.py
+++ b/addon/globalPlugins/openai/__init__.py
@@ -461,7 +461,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		# initialize the client with the first available provider, will be adjusted on the fly if needed
 		for provider in apikeymanager.AVAILABLE_PROVIDERS:
 			manager = apikeymanager.get(provider)
-			if not manager.ready:
+			if not manager.isReady():
 				continue
 			api_key = manager.get_api_key()
 			if not api_key or not api_key.strip():

--- a/addon/globalPlugins/openai/apikeymanager.py
+++ b/addon/globalPlugins/openai/apikeymanager.py
@@ -82,7 +82,7 @@ class APIKeyManager:
 		else:
 			self.api_key = key
 
-	def ready(self):
+	def isReady(self):
 		return self.get_api_key() is not None
 
 

--- a/addon/globalPlugins/openai/maindialog.py
+++ b/addon/globalPlugins/openai/maindialog.py
@@ -483,7 +483,7 @@ class OpenAIDlg(wx.Dialog):
 		self._historyPath = None
 		self.blocks = []
 		self._models = MODELS.copy()
-		if apikeymanager.get("OpenRouter").ready():
+		if apikeymanager.get("OpenRouter").isReady():
 			self._models.extend(getOpenRouterModels())
 		self.pathList = []
 		self._fileToRemoveAfter = []
@@ -508,7 +508,7 @@ class OpenAIDlg(wx.Dialog):
 			self.data.pop("system", None)
 		l = []
 		for manager in apikeymanager._managers.values():
-			if not manager.ready():
+			if not manager.isReady():
 				continue
 			e = manager.provider
 			organization = manager.get_api_key(use_org=True)
@@ -901,7 +901,7 @@ class OpenAIDlg(wx.Dialog):
 				wx.OK | wx.ICON_ERROR
 			)
 			return
-		if not apikeymanager.get(model.provider).ready():
+		if not apikeymanager.get(model.provider).isReady():
 			gui.messageBox(
 				_("This model is only available with the %s provider. Please provide an API key for this provider in the add-on settings. Otherwise, please select another model with a different provider.") % (
 					model.provider


### PR DESCRIPTION
- Fixed bug where code was calling `ready` method directly instead of checking its return value. This could lead to errors if `ready` returned false. 
- Renamed `ready` method to `isReady()` to be more clear on its purpose of checking if ready.

Thanks to @Neurrone  for reporting this issue in #69.