### PR TITLE
Adding encoding to fix the scons pot command issue

### DIFF
--- a/addon/globalPlugins/openai/consts.py
+++ b/addon/globalPlugins/openai/consts.py
@@ -1,3 +1,4 @@
+# coding:utf-8
 import os
 import sys
 import globalVars


### PR DESCRIPTION
Closes #85  to add encoding to the const.py file to make the scons pot command work again.